### PR TITLE
Feature/additional dns string

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 composer require sunaoka/laravel-postgres-extension
 ```
 
+## Configurations
+
+```bash
+php artisan vendor:publish --tag=postgres-extension
+```
+
 ## Features
 
 - Range Types

--- a/config/postgres-extension.php
+++ b/config/postgres-extension.php
@@ -3,4 +3,5 @@
 return [
     'json_encode_options'        => JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION,
     'information_schema_caching' => true,
+    'additional_dns_string'      => sprintf(";application_name='%s'", env('DB_APPLICATION_NAME', env('APP_NAME'))),
 ];

--- a/config/postgres-extension.php
+++ b/config/postgres-extension.php
@@ -3,5 +3,5 @@
 return [
     'json_encode_options'        => JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION,
     'information_schema_caching' => true,
-    'additional_dns_string'      => sprintf(";application_name='%s'", env('DB_APPLICATION_NAME', env('APP_NAME'))),
+    'additional_dns_string'      => '',
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
     </coverage>
 
     <php>
+        <env name="APP_NAME" value="Laravel extended PostgreSQL driver"/>
         <env name="DB_CONNECTION" value="pgsql"/>
     </php>
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,7 +24,6 @@
     </coverage>
 
     <php>
-        <env name="APP_NAME" value="Laravel extended PostgreSQL driver"/>
         <env name="DB_CONNECTION" value="pgsql"/>
     </php>
 

--- a/src/Connectors/PostgresConnector.php
+++ b/src/Connectors/PostgresConnector.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Sunaoka\LaravelPostgres\Connectors;
+
+use Illuminate\Support\Facades\Config;
+
+class PostgresConnector extends \Illuminate\Database\Connectors\PostgresConnector
+{
+    /**
+     * Create a DSN string from a configuration.
+     *
+     * @param  array  $config
+     * @return string
+     */
+    protected function getDsn(array $config): string
+    {
+        $dsn = parent::getDsn($config);
+
+        $dsn .= Config::get('postgres-extension.additional_dns_string');
+
+        return $dsn;
+    }
+}

--- a/src/PostgresServiceProvider.php
+++ b/src/PostgresServiceProvider.php
@@ -6,6 +6,7 @@ namespace Sunaoka\LaravelPostgres;
 
 use Illuminate\Database\Connection;
 use Illuminate\Support\ServiceProvider;
+use Sunaoka\LaravelPostgres\Connectors\PostgresConnector;
 
 class PostgresServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,8 @@ class PostgresServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__ . '/../config/postgres-extension.php', 'postgres-extension'
         );
+
+        $this->app->bind('db.connector.pgsql', PostgresConnector::class);
 
         Connection::resolverFor('pgsql', function ($connection, $database, $prefix, $config) {
             return new PostgresConnection($connection, $database, $prefix, $config);

--- a/tests/PostgresConnectorTest.php
+++ b/tests/PostgresConnectorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sunaoka\LaravelPostgres\Tests;
+
+use ReflectionException;
+use ReflectionMethod;
+use Sunaoka\LaravelPostgres\Connectors\PostgresConnector;
+
+class PostgresConnectorTest extends TestCase
+{
+    /**
+     * @throws ReflectionException
+     */
+    public function testGetDsn(): void
+    {
+        $method = new ReflectionMethod(PostgresConnector::class, 'getDsn');
+        $method->setAccessible(true);
+
+        $actual = $method->invoke(new PostgresConnector(), [
+            'database' => 'forge',
+        ]);
+
+        self::assertSame("pgsql:dbname='forge';application_name='Laravel extended PostgreSQL driver'", $actual);
+    }
+}

--- a/tests/PostgresConnectorTest.php
+++ b/tests/PostgresConnectorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sunaoka\LaravelPostgres\Tests;
 
+use Illuminate\Support\Facades\Config;
 use ReflectionException;
 use ReflectionMethod;
 use Sunaoka\LaravelPostgres\Connectors\PostgresConnector;
@@ -22,6 +23,14 @@ class PostgresConnectorTest extends TestCase
             'database' => 'forge',
         ]);
 
-        self::assertSame("pgsql:dbname='forge';application_name='Laravel extended PostgreSQL driver'", $actual);
+        self::assertSame("pgsql:dbname='forge'", $actual);
+
+        Config::set('postgres-extension.additional_dns_string', ";application_name='Laravel'");
+
+        $actual = $method->invoke(new PostgresConnector(), [
+            'database' => 'forge',
+        ]);
+
+        self::assertSame("pgsql:dbname='forge';application_name='Laravel'", $actual);
     }
 }


### PR DESCRIPTION
Support for adding any DNS string.

**config/postgres-extension.php**

```php
return [
    'json_encode_options'        => JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION,
    'information_schema_caching' => true,
    'additional_dns_string'      => ";application_name='Laravel'",
];
```